### PR TITLE
fix:修复Carousel第一次快速滚动到最左边，位置监听不正确

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -916,7 +916,8 @@ export default class Carousel extends Component {
             return;
         }
 
-        if (this._currentContentOffset === this._scrollEndOffset) {
+        // 修复 第一次快速滚动到最左边 监听不到滚动位置的问题
+        if (this._currentContentOffset != 0 && this._currentContentOffset === this._scrollEndOffset) {
             return;
         }
 


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：
- close #8 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

无

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->
