### PR TITLE
Add:Add the stopAutoplayWhenInvisible property to control whether the carousel stops automatic playback when it is outside the visible viewport.

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Animated, Easing, FlatList, I18nManager, Platform, ScrollView, View } from 'react-native';
+import { Animated, Easing, FlatList, I18nManager, Platform, ScrollView, View, Dimensions, UIManager, findNodeHandle } from 'react-native';
 import { ViewPropTypes} from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
@@ -64,6 +64,7 @@ export default class Carousel extends Component {
         slideInterpolatedStyle: PropTypes.func,
         slideStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         shouldOptimizeUpdates: PropTypes.bool,
+        stopAutoplayWhenInvisible: PropTypes.bool,
         swipeThreshold: PropTypes.number,
         useScrollView: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
         vertical: PropTypes.bool,
@@ -98,6 +99,7 @@ export default class Carousel extends Component {
         scrollEnabled: true,
         slideStyle: {},
         shouldOptimizeUpdates: true,
+        stopAutoplayWhenInvisible: false,
         swipeThreshold: 20,
         useScrollView: !AnimatedFlatList,
         vertical: false
@@ -128,6 +130,9 @@ export default class Carousel extends Component {
         this._onScrollTriggered = true; // used when momentum is enabled to prevent an issue with edges items
         this._lastScrollDate = 0; // used to work around a FlatList bug
         this._scrollEnabled = props.scrollEnabled !== false;
+        this._isVisible = true;
+        this._visibilityPollInterval = null;
+        this._lastInvisibleThrottleTs = 0;
 
         this._initPositionsAndInterpolators = this._initPositionsAndInterpolators.bind(this);
         this._renderItem = this._renderItem.bind(this);
@@ -184,6 +189,7 @@ export default class Carousel extends Component {
 
         this._mounted = true;
         this._initPositionsAndInterpolators();
+        this._startVisibilityMonitor();
 
         // Without 'requestAnimationFrame' or a `0` timeout, images will randomly not be rendered on Android...
         requestAnimationFrame(() => {
@@ -214,7 +220,7 @@ export default class Carousel extends Component {
 
     componentDidUpdate (prevProps) {
         const { interpolators } = this.state;
-        const { firstItem, itemHeight, itemWidth, scrollEnabled, sliderHeight, sliderWidth } = this.props;
+        const { firstItem, itemHeight, itemWidth, scrollEnabled, sliderHeight, sliderWidth, stopAutoplayWhenInvisible } = this.props;
         const itemsLength = this._getCustomDataLength(this.props);
 
         if (!itemsLength) {
@@ -229,6 +235,7 @@ export default class Carousel extends Component {
         const hasNewItemWidth = itemWidth && itemWidth !== prevProps.itemWidth;
         const hasNewItemHeight = itemHeight && itemHeight !== prevProps.itemHeight;
         const hasNewScrollEnabled = scrollEnabled !== prevProps.scrollEnabled;
+        const hasNewStopAutoplayWhenInvisible = stopAutoplayWhenInvisible !== prevProps.stopAutoplayWhenInvisible;
 
         // Prevent issues with dynamically removed items
         if (nextActiveItem > itemsLength - 1) {
@@ -238,6 +245,16 @@ export default class Carousel extends Component {
         // Handle changing scrollEnabled independent of user -> carousel interaction
         if (hasNewScrollEnabled) {
             this._setScrollEnabled(scrollEnabled);
+        }
+
+        if (hasNewStopAutoplayWhenInvisible) {
+            if (stopAutoplayWhenInvisible) {
+                this._startVisibilityMonitor();
+            } else {
+                this._stopVisibilityMonitor();
+                this._isVisible = true;
+                this._onVisibilityChanged();
+            }
         }
 
         if (interpolators.length !== itemsLength || hasNewSliderWidth ||
@@ -278,6 +295,10 @@ export default class Carousel extends Component {
         clearTimeout(this._snapNoMomentumTimeout);
         clearTimeout(this._edgeItemTimeout);
         clearTimeout(this._lockScrollTimeout);
+        if (this._visibilityPollInterval) {
+            clearInterval(this._visibilityPollInterval);
+            this._visibilityPollInterval = null;
+        }
     }
 
     get realIndex () {
@@ -494,6 +515,70 @@ export default class Carousel extends Component {
 
     _getScrollEnabled () {
         return this._scrollEnabled;
+    }
+
+    _getAutoplayInterval () {
+        const { autoplayInterval, stopAutoplayWhenInvisible } = this.props;
+
+        if (!stopAutoplayWhenInvisible) {
+            return autoplayInterval;
+        }
+
+        return this._isVisible ? autoplayInterval : 3600000;
+    }
+
+    _startVisibilityMonitor () {
+        if (!this.props.stopAutoplayWhenInvisible || this._visibilityPollInterval) {
+            return;
+        }
+
+        this._visibilityPollInterval = setInterval(() => this._updateVisibility(), 10);
+    }
+
+    _stopVisibilityMonitor () {
+        if (this._visibilityPollInterval) {
+            clearInterval(this._visibilityPollInterval);
+            this._visibilityPollInterval = null;
+        }
+    }
+
+    _updateVisibility () {
+        const ref = this._getWrappedRef();
+
+        if (!ref) {
+            return;
+        }
+
+        const handle = findNodeHandle(ref);
+
+        if (!handle) {
+            return;
+        }
+
+        UIManager.measureInWindow(handle, (x, y, width, height) => {
+            const { height: viewportHeight } = Dimensions.get('window');
+            const visible = (y + height) > 0 && y < viewportHeight && height > 0;
+
+            if (visible !== this._isVisible) {
+                this._isVisible = visible;
+                this._onVisibilityChanged();
+            }
+        });
+    }
+
+    _onVisibilityChanged () {
+        if (this._autoplay && this._autoplaying) {
+            clearInterval(this._autoplayInterval);
+            this._autoplayInterval = setInterval(() => {
+                if (this._autoplaying) {
+                    this.snapToNext();
+                }
+            }, this._getAutoplayInterval());
+        }
+
+        if (this._isVisible) {
+            this._lastInvisibleThrottleTs = 0;
+        }
     }
 
     _setScrollEnabled (scrollEnabled = true) {
@@ -1095,7 +1180,7 @@ export default class Carousel extends Component {
     }
 
     startAutoplay () {
-        const { autoplayInterval, autoplayDelay } = this.props;
+        const { autoplayDelay } = this.props;
         this._autoplay = true;
 
         if (this._autoplaying) {
@@ -1109,7 +1194,7 @@ export default class Carousel extends Component {
                 if (this._autoplaying) {
                     this.snapToNext();
                 }
-            }, autoplayInterval);
+            }, this._getAutoplayInterval());
         }, autoplayDelay);
     }
 
@@ -1140,6 +1225,18 @@ export default class Carousel extends Component {
     }
 
     snapToNext (animated = true, fireCallback = true) {
+        const { stopAutoplayWhenInvisible } = this.props;
+
+        if (stopAutoplayWhenInvisible && !this._isVisible) {
+            const now = Date.now();
+
+            if (this._lastInvisibleThrottleTs && now - this._lastInvisibleThrottleTs < 3600000) {
+                return;
+            }
+
+            this._lastInvisibleThrottleTs = now;
+        }
+
         const itemsLength = this._getCustomDataLength();
 
         let newIndex = this._activeItem + 1;
@@ -1153,6 +1250,18 @@ export default class Carousel extends Component {
     }
 
     snapToPrev (animated = true, fireCallback = true) {
+        const { stopAutoplayWhenInvisible } = this.props;
+
+        if (stopAutoplayWhenInvisible && !this._isVisible) {
+            const now = Date.now();
+
+            if (this._lastInvisibleThrottleTs && now - this._lastInvisibleThrottleTs < 3600000) {
+                return;
+            }
+
+            this._lastInvisibleThrottleTs = now;
+        }
+
         const itemsLength = this._getCustomDataLength();
 
         let newIndex = this._activeItem - 1;


### PR DESCRIPTION
  ### Platforms affected
  - OpenHarmony / OHOS
  - Potentially all React Native platforms supported by this library, since the change is implemented
  in shared JS carousel logic


  ### What does this PR do?
  This PR adds a new optional prop: `stopAutoplayWhenInvisible`.

  When `autoplay` is enabled and `stopAutoplayWhenInvisible={true}`, the carousel checks whether it
  is currently visible in the viewport. If the carousel is scrolled out of view, autoplay is paused/
  stopped from advancing items. When the carousel becomes visible again, autoplay resumes
  automatically.

  Key points:
  - Default behavior remains unchanged (`stopAutoplayWhenInvisible` defaults to `false`)
  - No impact on existing users unless the new prop is explicitly enabled
  - The change is intended to reduce unnecessary autoplay work when the carousel is off-screen


  ### What testing has been done on this change?
  - Ran the local demo in the OHOS tester/app demo with autoplay enabled
  - Verified that behavior is unchanged when `stopAutoplayWhenInvisible={false}`
  - Verified that autoplay continues normally while the carousel is visible when
  `stopAutoplayWhenInvisible={true}`
  - Verified that autoplay stops advancing when the carousel is scrolled out of the visible viewport
  - Verified that autoplay resumes after scrolling back and making the carousel visible again
  - Checked trace behavior during visible/invisible periods to confirm that off-screen autoplay
  activity is reduced compared with the visible state
  - Performed a basic regression check on the existing autoplay + loop demo path


  ### Tested features checklist
  <!--
  IMPORTANT: Please make sure that none of these features have been broken by your changes.
  It's easy to overlook something you didn't use yet.
  -->
  - [x] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/
  example/src/index.js#L46-L87))
  - [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/
  archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
  - [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/
  blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
  - [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-
  carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
  - [x] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/
  master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
  - [x] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/
  doc/PROPS_METHODS_AND_GETTERS.md#loop))
  - [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-
  native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
  - [ ] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/
  PROPS_METHODS_AND_GETTERS.md#callbacks)
  - [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-
  carousel#parallaximage-component)
  - [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-
  component)
  - [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-
  carousel#layouts-and-custom-interpolations)

